### PR TITLE
enhance toggling of indicators (#someday and 🔼)

### DIFF
--- a/Utility/Scripts/Templater/_init_template.js
+++ b/Utility/Scripts/Templater/_init_template.js
@@ -83,6 +83,25 @@ function main(target) {
     }
   }
 
+  /**
+   * set the text of the current line, if in editing mode
+   * @param {string}
+   * @returns {boolean}
+   */
+  target.setCurrentLine = function (newLineContent) {
+    if (!target.isEditMode()) {
+      // Not in edit mode, current line is unknowable
+      return false
+    } else {
+      const lineNumber = target.view.editor.getCursor().line
+      target.view.editor.setLine(lineNumber, newLineContent)
+      // move cursor to end of line
+      target.view.editor.setCursor({ line: lineNumber, ch: newLineContent.length })
+
+      return true
+    }
+  }
+
   target.goToFile = async function (path) {
     const file = app.vault.getAbstractFileByPath(path)
     if (path !== target.file.path) {


### PR DESCRIPTION
This PR enhances the toggling of indicators.

Before, toggling #someday using the templater menu only added the tag and did not remove it again (making it a real toggle).
The code for toggling an indicator has been factored out, so that another toggle could be added easily: 🔼

The toggle code has been reworked to be more robust, i.e. removing multiple occurrences of the indicator and trimming the line in the end including cursor placement and checking if we are really on a task line.

This PR contains two unrelated bugfixes:
1. not calling the archive function when there is nothing to archive
2. fixed a typo in the configuration for the completedTasksNote