### PR TITLE
Display 0% project progress bar even if no tasks exist yet

### DIFF
--- a/Utility/Scripts/Dataview/project-progress.js
+++ b/Utility/Scripts/Dataview/project-progress.js
@@ -1,3 +1,3 @@
 const tasks = dv.current().file.tasks
 const percent = Math.round(tasks.filter(x => x.completed).length / tasks.length * 100)
-dv.paragraph(`![](https://progress-bar.dev/${percent}/?width=200&title=Progress&color=333333)`)
+dv.paragraph(`![](https://progress-bar.dev/${percent|| 0}/?width=200&title=Progress&color=333333)`)


### PR DESCRIPTION
Fix broken image icon that appeared when no tasks were added for a project and show a 0% progress bar instead.