### PR TITLE
Handle exclusion of cancelled tasks ("- [-]")

### DIFF
--- a/Utility/Scripts/Dataview/tasks.js
+++ b/Utility/Scripts/Dataview/tasks.js
@@ -131,7 +131,7 @@ dv.pages('-#project' + globalExcludeString)
     page.tasks
       .where(t =>
         t.text && // where the task has text (is not blank)
-        !t.completed && // and not completed
+        !(t.completed || t.status == "-") && // and not completed or cancelled
         !t.tags.includes('#exclude') && // and not excluded
         (!t.header.subpath || !t.header.subpath.includes('exclude')) &&
         !globalExclude.headings.includes(t.header.subpath) // and the heading is not excluded


### PR DESCRIPTION
Tasks plugin supports marking items cancelled in this way, but the current implementation shows those in Next actions. This change removes them along with the already removed completed tasks.